### PR TITLE
Update the introductory note on the global Conventions attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ This document is a standard for storing unstructured grid
 (a.k.a. unstructured mesh, flexible mesh)
 model data in a Unidata Network Common Data Form (NetCDF) file.
 
-Note: NetCDF files using this convention can be be given the global attribute `Conventions = 'CF-1.6,
-UGRID-1.0'` if they are CF- and UGRID-compliant,
-or just `Conventions = 'UGRID-1.0'` if they are not CF-compliant. 
+Note: It's recommended to give netCDF files adhering to the UGRID conventions the global attribute `Conventions = 'UGRID-1.0'`; if the file is also compliant with the Climate and Forecasting conventions then the global attribute can be extended to `Conventions = 'CF-1.6, UGRID-1.0'` with `1.6` replaced by the appropriate CF conventions version number. As of CF version 1.11 (draft), the CF-conventions include the UGRID 1.0 conventions by reference. In that case `Conventions = 'CF-1.11-draft'` or later CF-version attribute is sufficient.
 * [Version 1.0](http://ugrid-conventions.github.io/ugrid-conventions/)
 
 The standard was developed over a period of several years through the

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ The standard was developed over a period of several years through the
 [UGRID Google Group](https://groups.google.com/forum/#!forum/ugrid-interoperability)
 which had members from many different unstructured grid modeling communities
 (including SELFE, ELCIRC, FVCOM, ADCIRC).
-From these discussions Bert Jagers (Deltares) created the first draft of this document.
-We will likely propose this as a CF Standard once it has been fully tested by the community.
-
+From these discussions Bert Jagers (Deltares) created the first draft of this document, and the community worked to develop version 1.0.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This document is a standard for storing unstructured grid
 (a.k.a. unstructured mesh, flexible mesh)
 model data in a Unidata Network Common Data Form (NetCDF) file.
 
-Note: It's recommended to give netCDF files adhering to the UGRID conventions the global attribute `Conventions = 'UGRID-1.0'`; if the file is also compliant with the Climate and Forecasting conventions then the global attribute can be extended to `Conventions = 'CF-1.6, UGRID-1.0'` with `1.6` replaced by the appropriate CF conventions version number. As of CF version 1.11 (draft), the CF-conventions include the UGRID 1.0 conventions by reference. In that case `Conventions = 'CF-1.11-draft'` or later CF-version attribute is sufficient.
+Note: It's recommended to give netCDF files adhering to the UGRID conventions the global attribute `Conventions = 'UGRID-1.0'`; if the file is also compliant with the Climate and Forecasting conventions then the global attribute can be extended to `Conventions = 'CF-1.6, UGRID-1.0'` with `1.6` replaced by the appropriate CF conventions version number. As of CF version 1.11, the CF-conventions include the UGRID 1.0 conventions by reference. In that case `Conventions = 'CF-1.11'` or later CF-version attribute is sufficient.
 * [Version 1.0](http://ugrid-conventions.github.io/ugrid-conventions/)
 
 The standard was developed over a period of several years through the


### PR DESCRIPTION
Following the inclusion of UGRID-1.0 in CF-1.11 (draft) conventions, we should update the remark concerning the global `Conventions` attribute. Specifying `CF-1.11-draft` or later is considered enough.

This pull request addresses issue #68 