### PR TITLE
Fix broken URL to Bundesanstalt für Wasserbau netCDF pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The UGRID conventions are developed in public at <https://github.com/ugrid-conve
 Anybody is welcome to contribute using the common open-source GitHub workflow ([fork and branch](https://gist.github.com/Chaser324/ce0505fbed06b947d962)).
 
 The definitive source of the conventions can be found in the ``src`` directory in the ``master`` branch.
-To generate the HTML from of the conventions, ``mkdocs`` is used.
+To generate the HTML form of the conventions, ``mkdocs`` is used.
 The ``requirements.txt`` file in the UGRID repository is the recommended approach to installing the necessary tools:
 
 ```

--- a/src/index.md
+++ b/src/index.md
@@ -24,7 +24,7 @@ Known issues left for future versions include:
 
 * adaptive mesh topology (this could be supported by defining a `time_concatenation` attribute for a time-series of mesh topologies)
 * higher order element data; for an idea how such data could be stored see this other [proposal](https://publicwiki.deltares.nl/display/NETCDF/Finite+Element+based+CF+proposal+for+Unstructured+Grid+data+model).
-* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages (in German)](http://www.baw.de/methoden/index.php5/NetCDF)).
+* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages (in German)](https://wiki.baw.de/de/index.php?title=NetCDF)).
 * 3D fully unstructured meshes (some concepts are included here, but still somewhat limited in scope).
 * multiply-connected domains
 * ghost elements

--- a/src/index.md
+++ b/src/index.md
@@ -24,7 +24,7 @@ Known issues left for future versions include:
 
 * adaptive mesh topology (this could be supported by defining a `time_concatenation` attribute for a time-series of mesh topologies)
 * higher order element data; for an idea how such data could be stored see this other [proposal](https://publicwiki.deltares.nl/display/NETCDF/Finite+Element+based+CF+proposal+for+Unstructured+Grid+data+model).
-* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages (in German)](https://wiki.baw.de/de/index.php?title=NetCDF)).
+* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages](https://wiki.baw.de/en/index.php/NetCDF)).
 * 3D fully unstructured meshes (some concepts are included here, but still somewhat limited in scope).
 * multiply-connected domains
 * ghost elements


### PR DESCRIPTION
Hi, I was studying UGRID towards some visualisation work I am conducting for the library cf-plot and I noticed there is a broken link under the ['Known Issues' page](https://ugrid-conventions.github.io/ugrid-conventions/#known-issues):

> subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages (in German)](http://www.baw.de/methoden/index.php5/NetCDF)).

where the link in question that doesn't work is: ``http://www.baw.de/methoden/index.php5/NetCDF`` which leads to a '404 Not Found' error.

Based on the redirection that links takes to a new domain `wiki.baw.de` (though to a broken path under that), I found the [NetCDF pages](https://wiki.baw.de/de/index.php?title=NetCDF) which I believe should be linked to as the equivalent URL to the previous, updated to the new domain and path under it. So I thought I'd put in a PR to fix it, since itis a one-line change (though I also noticed a typo in the README I've included a fix for). Note I've included a change to `https` from `http` as the secure protocol for a URL, though this updated link works with eithel protocol.

Thanks.