### PR TITLE
Fix BAW link

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -24,7 +24,7 @@ Known issues left for future versions include:
 
 * adaptive mesh topology (this could be supported by defining a `time_concatenation` attribute for a time-series of mesh topologies)
 * higher order element data; for an idea how such data could be stored see this other [proposal](https://publicwiki.deltares.nl/display/NETCDF/Finite+Element+based+CF+proposal+for+Unstructured+Grid+data+model).
-* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages](https://wiki.baw.de/de/index.php?title=NetCDF)).
+* subgrid data; the NetCDF pages by the Bundesanstalt für Wasserbau (BAW) contain some proposals on this topic ([see their pages](https://wiki.baw.de/en/index.php?title=NetCDF)).
 * 3D fully unstructured meshes (some concepts are included here, but still somewhat limited in scope).
 * multiply-connected domains
 * ghost elements


### PR DESCRIPTION
404 on https://wiki.baw.de/en/index.php5/NetCDF

Fixed link: https://wiki.baw.de/en/index.php?title=NetCDF

Compare with wayback machine: https://web.archive.org/web/20170928114752/https://wiki.baw.de/en/index.php5/NetCDF